### PR TITLE
Changes headlights initialization to be in sync with arduino

### DIFF
--- a/Main/Peripherals/src/Drivers/Headlights.cpp
+++ b/Main/Peripherals/src/Drivers/Headlights.cpp
@@ -6,8 +6,8 @@
 
 Headlights::Headlights(Serial& serial) : serial_(serial)
 {
-	areOn = false;
-}
+	areOn = true; // Initialized as true because Poseidon's headlights are
+}				//		are turned on by the arduino in its initialization
 
 void Headlights::switchLights()
 {


### PR DESCRIPTION
This change initializes the headlights' state as already turned
on in order to reflect how the state of the headlights when
the headlights class is initialized.  This is a fix to a bug that
required you to call switchLights twice in order to toggle the lights
for the first time.