### PR TITLE
Changed Compass Data Type

### DIFF
--- a/Main/Peripherals/include/Drivers/HMC5883L.h
+++ b/Main/Peripherals/include/Drivers/HMC5883L.h
@@ -106,17 +106,17 @@ class HMC5883L
         /** \brief Reads the X-direction of the greatest polar field.
           * \return Returns a signed short value ranging from -2048 to 2047.
           */
-        uint16_t X();
+        int16_t X();
 
         /** \brief Reads the Y-direction of the greatest polar field.
           * \return Returns a signed short value ranging from -2048 to 2047.
           */
-        uint16_t Y();
+        int16_t Y();
 
         /** \brief Reads the Z-direction of the greatest polar field.
           * \return Returns a signed short value ranging from -2048 to 2047.
           */
-        uint16_t Z();
+        int16_t Z();
 
 
 

--- a/Main/Peripherals/src/Drivers/HMC5883L.cpp
+++ b/Main/Peripherals/src/Drivers/HMC5883L.cpp
@@ -17,20 +17,20 @@ HMC5883L::~HMC5883L() {}
 
 
 
-uint16_t HMC5883L::X() {
-    return I2C::readShort(IMU_COMPASS_ADDR, IMU_COMPASS_X_H);
+int16_t HMC5883L::X() {
+    return static_cast<int16_t>(I2C::readShort(IMU_COMPASS_ADDR, IMU_COMPASS_X_H));
 }
 
 
 
-uint16_t HMC5883L::Y() {
-    return I2C::readShort(IMU_COMPASS_ADDR, IMU_COMPASS_Y_H);
+int16_t HMC5883L::Y() {
+    return static_cast<int16_t>(I2C::readShort(IMU_COMPASS_ADDR, IMU_COMPASS_Y_H));
 }
 
 
 
-uint16_t HMC5883L::Z() {
-    return I2C::readShort(IMU_COMPASS_ADDR, IMU_COMPASS_Z_H);
+int16_t HMC5883L::Z() {
+    return static_cast<int16_t>(I2C::readShort(IMU_COMPASS_ADDR, IMU_COMPASS_Z_H));
 }
 
 


### PR DESCRIPTION
I noticed when reviewing the logs that 'negative' values would cause instant jumps in the graph. This is fixed by returning the correct 2's compliment short instead.