### PR TITLE
Fixes "Inappropriate ioctl for device"

### DIFF
--- a/Scripts/reset_usb_ioctl.sh
+++ b/Scripts/reset_usb_ioctl.sh
@@ -10,4 +10,4 @@ echo -n "1-1:1.0" > /sys/bus/usb/drivers/cdc_acm/bind
 
 # rename device descriptor to original name
 file=$(find /dev -name "ttyACM*" -print)
-rm $file $dev
+mv $file $dev

--- a/Scripts/reset_usb_ioctl.sh
+++ b/Scripts/reset_usb_ioctl.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# remove broken device file descriptor
+dev="/dev/ttyACM0"
+if [ -e $dev ]; then rm /dev/ttyACM0; fi
+
+# recreate device descriptor
+echo -n "1-1:1.0" > /sys/bus/usb/drivers/cdc_acm/unbind
+echo -n "1-1:1.0" > /sys/bus/usb/drivers/cdc_acm/bind
+
+# rename device descriptor to original name
+file=$(find /dev -name "ttyACM*" -print)
+rm $file $dev


### PR DESCRIPTION
Resets the stty device descriptor without performing a soft or hard
reset of the system

This resolves #43 