### PR TITLE
Removes reference to `cmdString`

### DIFF
--- a/Main/WebApplication/index.js
+++ b/Main/WebApplication/index.js
@@ -41,7 +41,7 @@ app.post('/goDirection', function(req, res) {
 
 app.post('/faceDirection', function(req, res) {
 	thrustController.faceDirection(req.body.yaw)
-	res.send(cmdString);
+	res.send('');
 });
 
 


### PR DESCRIPTION
Solves the "cmdString is undefined" exception when yawing.