### PR TITLE
Fixed Unable to Make Back-to-Back IMU Calls

### DIFF
--- a/BoneCentral/Brain/CppInterface/ImuSensor.js
+++ b/BoneCentral/Brain/CppInterface/ImuSensor.js
@@ -24,16 +24,20 @@ module.exports = (function(){
 
     var _handleData = function(self){return function (data) {
         try {
-            var dataJson = JSON.parse(data.toString());
-            if (dataJson.Type == "Acceleration") self._accelRequest.resolve(dataJson);
-            else if (dataJson.Type == "AngularAcceleration") self._angularAccelRequest.resolve(dataJson);
-            else if (dataJson.Type == "Heading") self._headingRequest.resolve(dataJson);
-            else if (dataJson.Type == "InternalTemperature") self._inTempRequest.resolve(dataJson);
-            else if (dataJson.Type == "InternalPressure") self._inPressureRequest.resolve(dataJson);
-            else if (dataJson.Type == "ExternalTemperature") self._exTempRequest.resolve(dataJson);
-            else if (dataJson.Type == "ExternalPressure") self._exPressureRequest.resolve(dataJson);
+            var tokens = data.toString().split('\n');
+            for(i = 0; i < tokens.length-1; i++) {
+                var dataJson = JSON.parse(tokens[i]+"\n");
+                if      (dataJson.Type === "Acceleration")           self._accelRequest.resolve(dataJson);
+                else if (dataJson.Type === "AngularAcceleration")    self._angularAccelRequest.resolve(dataJson);
+                else if (dataJson.Type === "Heading")                self._headingRequest.resolve(dataJson);
+                else if (dataJson.Type === "InternalTemperature")    self._inTempRequest.resolve(dataJson);
+                else if (dataJson.Type === "InternalPressure")       self._inPressureRequest.resolve(dataJson);
+                else if (dataJson.Type === "ExternalTemperature")    self._exTempRequest.resolve(dataJson);
+                else if (dataJson.Type === "ExternalPressure")       self._exPressureRequest.resolve(dataJson);
+                else { console.log("Could not resolved type '"+dataJson.Type+"'"); }
+            }
         }
-        catch(e) {}
+        catch(e) { console.log("_handleData: "+e); }
     };};
 
     ImuSensor.prototype.getAcceleration = function () {


### PR DESCRIPTION
Turns out handled data ended up being concatenations of JSON object strings which parsed to invalid JSON objects. This left promises unresolved. The simple fix was to split them using the available newline character and then iterate through each token.