### PR TITLE
Hardware App Promises

### DIFF
--- a/BoneCentral/Brain/CppInterface/Factory.js
+++ b/BoneCentral/Brain/CppInterface/Factory.js
@@ -30,7 +30,7 @@ module.exports = (function() {
     };
 
     Factory.prototype.createPowerManager = function () {
-        return new PowerManager(this.dispatcherSocket.Input, this.dispatcherSocket.OnExit);
+        return new PowerManager(this.dispatcherSocket.Input, this.dispatcherSocket.Events);
     };
 
     Factory.prototype.createThrustController = function () {

--- a/BoneCentral/Brain/CppInterface/Factory.js
+++ b/BoneCentral/Brain/CppInterface/Factory.js
@@ -30,7 +30,7 @@ module.exports = (function() {
     };
 
     Factory.prototype.createPowerManager = function () {
-        return new PowerManager(dispatcherSocket.Input);
+        return new PowerManager(this.dispatcherSocket.Input, this.dispatcherSocket.OnExit);
     };
 
     Factory.prototype.createThrustController = function () {

--- a/BoneCentral/Brain/CppInterface/PowerManager.js
+++ b/BoneCentral/Brain/CppInterface/PowerManager.js
@@ -1,7 +1,8 @@
 module.exports = (function(){
 
-    function PowerManager(cmdOut) {
+    function PowerManager(cmdOut, onExit) {
         this._cmdOut = cmdOut;
+        this._onExit = onExit;
     }
 
     PowerManager.prototype.turnOnEscs = function(){
@@ -22,6 +23,7 @@ module.exports = (function(){
 
     PowerManager.prototype.exit = function () {
         this._cmdOut.write("exit\n");
+        return this._onExit;
     };
 
     return PowerManager;

--- a/BoneCentral/Brain/CppInterface/PowerManager.js
+++ b/BoneCentral/Brain/CppInterface/PowerManager.js
@@ -1,8 +1,8 @@
 module.exports = (function(){
 
-    function PowerManager(cmdOut, onExit) {
+    function PowerManager(cmdOut, events) {
         this._cmdOut = cmdOut;
-        this._onExit = onExit;
+        this._events = events;
     }
 
     PowerManager.prototype.turnOnEscs = function(){
@@ -20,10 +20,14 @@ module.exports = (function(){
     PowerManager.prototype.turnOffImu = function () {
         this._cmdOut.write("turnOffImuSensor\n");
     };
+    
+    PowerManager.prototype.connect = function() {
+        return this._events.OnConnect;
+    }
 
     PowerManager.prototype.exit = function () {
         this._cmdOut.write("exit\n");
-        return this._onExit;
+        return this._events.OnExit;
     };
 
     return PowerManager;

--- a/BoneCentral/Brain/Sockets/index.js
+++ b/BoneCentral/Brain/Sockets/index.js
@@ -3,15 +3,24 @@
  */
 
 var Streams = require('stream');
-var Net = require('net');
+var Net     = require('net');
+var $       = require('../Utilities').Promises
 
 module.exports.createSocket = function (port) {
-    var input = new Streams.PassThrough();
+    var input  = new Streams.PassThrough();
     var output = new Streams.PassThrough();
+    var onExit = $.Deferred();
     Net.createServer(function (socket) {
         _handleClient(socket, input, output);
+        socket.on("close", function() {
+            onExit.resolve();
+        });
     }).listen(port);
-    return {Input: input, Output: output};
+    return {
+        Input: input,
+        Output: output,
+        OnExit: onExit.promise()
+    };
 };
 
 var _handleClient = function (socket, input, output) {

--- a/BoneCentral/Brain/Sockets/index.js
+++ b/BoneCentral/Brain/Sockets/index.js
@@ -7,19 +7,26 @@ var Net     = require('net');
 var $       = require('../Utilities').Promises
 
 module.exports.createSocket = function (port) {
-    var input  = new Streams.PassThrough();
-    var output = new Streams.PassThrough();
-    var onExit = $.Deferred();
+    var input     = new Streams.PassThrough();
+    var output    = new Streams.PassThrough();
+    var onExit    = $.Deferred();
+    var onConnect = $.Deferred();
+    
     Net.createServer(function (socket) {
         _handleClient(socket, input, output);
         socket.on("close", function() {
             onExit.resolve();
         });
+        onConnect.resolve();
     }).listen(port);
+    
     return {
         Input: input,
         Output: output,
-        OnExit: onExit.promise()
+        Events: {
+            OnConnect: onConnect.promise(),
+            OnExit: onExit.promise()
+        }
     };
 };
 


### PR DESCRIPTION
These promises allow for better control and more flexibility with higher level scripts.

- `power.connect()` returns a promise that allows a script to wait for the C++ app to actually connect before making any calls to it.
- `power.exit()` now also returns a promise that allows a script to wait for the C++ app to properly shut down before the script its self exits.